### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -13,6 +13,12 @@ spacefm (1.0.6-5) UNRELEASED; urgency=medium
   [ Mateusz Łukasik ]
   * Fix FTBFS with gcc-10. (Closes: #957829)
 
+  [ Debian Janitor ]
+  * Remove constraints unnecessary since buster:
+    + spacefm: Drop versioned constraint on spacefm in Replaces.
+    + spacefm-common: Drop versioned constraint on spacefm in Replaces.
+    + spacefm-common: Drop versioned constraint on spacefm in Breaks.
+
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 02:26:03 +0000
 
 spacefm (1.0.6-4) unstable; urgency=medium

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Depends: ${misc:Depends}, ${shlibs:Depends}, spacefm-common (= ${source:Version}
  desktop-file-utils, shared-mime-info, e2fsprogs
 Recommends: udisks2
 Suggests: udevil, eject, lsof, wget, ktsuss, gksu, sshfs, dbus
-Replaces: spacefm-gtk3, spacefm (<< 0.9), spacefm-common (<< 1.0.5-2~)
+Replaces: spacefm-gtk3, spacefm-common (<< 1.0.5-2~)
 Conflicts: spacefm-hal, spacefm-gtk3
 Provides: spacefm-hal
 Breaks: spacefm-common (<< 1.0.5-2~)
@@ -43,8 +43,6 @@ Description: Multi-panel tabbed file manager - GTK2 version
 Package: spacefm-common
 Architecture: all
 Depends: ${misc:Depends}
-Replaces: spacefm (<< 0.9)
-Breaks: spacefm (<< 0.9)
 Recommends: spacefm | spacefm-gtk3, hicolor-icon-theme | faenza-icon-theme
 Description: Multi-panel tabbed file manager - common files
  SpaceFM is a multi-panel tabbed file and desktop manager for Linux with


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/spacefm/eb322ef2-0965-4ff5-9ba1-89b37ff13d60.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package spacefm: lines which differ (wdiff format)
* Replaces: [-spacefm (<< 0.9),-] spacefm-common (<< 1.0.5-2~), spacefm-gtk3
### Control files of package spacefm-common: lines which differ (wdiff format)
* [-Breaks: spacefm (<< 0.9)-]
* [-Replaces: spacefm (<< 0.9)-]

No differences were encountered between the control files of package \*\*spacefm-dbgsym\*\*

No differences were encountered between the control files of package \*\*spacefm-gtk3\*\*

No differences were encountered between the control files of package \*\*spacefm-gtk3-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/eb322ef2-0965-4ff5-9ba1-89b37ff13d60/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/eb322ef2-0965-4ff5-9ba1-89b37ff13d60/diffoscope)).
