### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+spacefm (1.0.6-6) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on libgtk2.0-dev.
+    + spacefm: Drop versioned constraint on spacefm and spacefm-common in
+      Replaces.
+    + spacefm: Drop versioned constraint on spacefm-common in Breaks.
+    + spacefm-common: Drop versioned constraint on spacefm in Replaces.
+    + spacefm-common: Drop versioned constraint on spacefm in Breaks.
+    + spacefm-gtk3: Drop versioned constraint on spacefm-common in Replaces.
+    + spacefm-gtk3: Drop versioned constraint on spacefm-common in Breaks.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 01 Mar 2022 15:44:51 -0000
+
 spacefm (1.0.6-5) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: spacefm
 Section: utils
 Priority: optional
 Maintainer: Mateusz Łukasik <mati75@linuxmint.pl>
-Build-Depends: debhelper-compat (= 11), libgtk2.0-dev (>= 2.24),
+Build-Depends: debhelper-compat (= 11), libgtk2.0-dev,
  libcairo2-dev, libpango1.0-dev, libx11-dev, intltool, pkg-config,
  libglib2.0-dev, libstartup-notification0-dev,
  libgdk-pixbuf2.0-dev, libudev-dev, hicolor-icon-theme, libgtk-3-dev,
@@ -18,10 +18,9 @@ Depends: ${misc:Depends}, ${shlibs:Depends}, spacefm-common (= ${source:Version}
  desktop-file-utils, shared-mime-info, e2fsprogs
 Recommends: udisks2
 Suggests: udevil, eject, lsof, wget, ktsuss, gksu, sshfs, dbus
-Replaces: spacefm-gtk3, spacefm (<< 0.9), spacefm-common (<< 1.0.5-2~)
+Replaces: spacefm-gtk3
 Conflicts: spacefm-hal, spacefm-gtk3
 Provides: spacefm-hal
-Breaks: spacefm-common (<< 1.0.5-2~)
 Description: Multi-panel tabbed file manager - GTK2 version
  SpaceFM is a multi-panel tabbed file and desktop manager for Linux with
  built-in VFS, udev or HAL-based device manager, customizable menu system
@@ -43,8 +42,6 @@ Description: Multi-panel tabbed file manager - GTK2 version
 Package: spacefm-common
 Architecture: all
 Depends: ${misc:Depends}
-Replaces: spacefm (<< 0.9)
-Breaks: spacefm (<< 0.9)
 Recommends: spacefm | spacefm-gtk3, hicolor-icon-theme | faenza-icon-theme
 Description: Multi-panel tabbed file manager - common files
  SpaceFM is a multi-panel tabbed file and desktop manager for Linux with
@@ -60,9 +57,8 @@ Depends: ${misc:Depends}, ${shlibs:Depends}, spacefm-common (= ${source:Version}
  desktop-file-utils, shared-mime-info, e2fsprogs
 Recommends: udisks2
 Suggests: udevil, eject, lsof, wget, ktsuss, gksu, sshfs, dbus
-Replaces: spacefm, spacefm-gtk3, spacefm-common (<< 1.0.5-2~)
+Replaces: spacefm, spacefm-gtk3
 Conflicts: spacefm-hal, spacefm
-Breaks: spacefm-common (<< 1.0.5-2~)
 Description: Multi-panel tabbed file manager - GTK3 version
  SpaceFM is a multi-panel tabbed file and desktop manager for Linux with
  built-in VFS, udev or HAL-based device manager, customizable menu system


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/spacefm/f2afd9b0-1b4d-4e97-95f6-835697bd15bc.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package spacefm: lines which differ (wdiff format)
* [-Breaks: spacefm-common (<< 1.0.5-2~)-]
* Replaces: [-spacefm (<< 0.9), spacefm-common (<< 1.0.5-2~),-] spacefm-gtk3
### Control files of package spacefm-common: lines which differ (wdiff format)
* [-Breaks: spacefm (<< 0.9)-]
* [-Replaces: spacefm (<< 0.9)-]

No differences were encountered between the control files of package \*\*spacefm-dbgsym\*\*
### Control files of package spacefm-gtk3: lines which differ (wdiff format)
* [-Breaks: spacefm-common (<< 1.0.5-2~)-]
* Replaces: spacefm, [-spacefm-common (<< 1.0.5-2~),-] spacefm-gtk3

No differences were encountered between the control files of package \*\*spacefm-gtk3-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f2afd9b0-1b4d-4e97-95f6-835697bd15bc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f2afd9b0-1b4d-4e97-95f6-835697bd15bc/diffoscope)).
